### PR TITLE
switch to Download::GitHub plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm --notest --with-recommends --with-suggests \
             ExtUtils::MakeMaker \
-            Alien::Build::MM
+            Alien::Build::MM \
+            Alien::Build::Plugin::Download::GitHub
       - name: Make distribution
         shell: bash
         run: |

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,11 +23,13 @@ WriteMakefile($abmm->mm_args(
   CONFIGURE_REQUIRES => {
     'Alien::Build'        => '1.41',
     'Alien::Build::MM'    => '1.41',
+    'Alien::Build::Plugin::Download::GitHub' => 0,
     'ExtUtils::MakeMaker' => '6.52',
   },
   BUILD_REQUIRES => {
     'Alien::Build'        => '1.41',
     'Alien::Build::MM'    => '1.41',
+    'Alien::Build::Plugin::Download::GitHub' => 0,
     'ExtUtils::MakeMaker' => '6.52',
   },
   PREREQ_PM => {

--- a/alienfile
+++ b/alienfile
@@ -27,9 +27,10 @@ share {
   requires 'Alien::gmake' => 0;
   requires 'Config';
 
-  start_url "https://github.com/ebiggers/libdeflate/releases";
-  plugin Download => (
-    filter => qr/^v.*\.tar\.gz$/,
+  plugin 'Download::GitHub' => (
+    github_user => 'ebiggers',
+    github_repo => 'libdeflate',
+    asset_name => qr/^v.*\.tar\.gz$/,
     version => qr/([0-9\.]+)/,
   );
 


### PR DESCRIPTION
The current GitHub releases pages are not parseable anymore, and the build used to fail in the download step. Fix by switching to the Download::GitHub plugin, which uses a hopefully stable API.