### PR TITLE
Set ffi_name for finding dynamic library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,5 +142,7 @@ jobs:
           echo "ALIEN_INSTALL_TYPE=${{ matrix.alien-install-type }}" >> $GITHUB_ENV
 
       - name: Run tests
+        env:
+          ALIEN_BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cpanm --verbose --test-only dist.tar.gz

--- a/alienfile
+++ b/alienfile
@@ -22,6 +22,15 @@ plugin 'Probe::CBuilder' => (
 int main(int argc, char *argv[]) { printf("%s\n", LIBDEFLATE_VERSION_STRING); return 0; }
 END_OF_CODE
 
+meta->around_hook( gather_system => sub {
+  my $orig = shift;
+  my ($build) = @_;
+  $orig->(@_);
+  if( ! exists $build->runtime_prop->{ffi_name} ) {
+    $build->runtime_prop->{ffi_name} = 'deflate';
+  }
+});
+
 share {
   ## *bsd make is incompatible
   requires 'Alien::gmake' => 0;


### PR DESCRIPTION
This is needed for FFI under a system install type.

Fixes <https://github.com/kiwiroy/alien-libdeflate/issues/3>.
